### PR TITLE
ci: use ghcr registry cache for deploy image builds

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -15,3 +15,5 @@ jobs:
       environment: Development
       enable-sentry: true
       docker-image: ghcr.io/AplinkosMinisterija/biip-hidro-api
+      cache-from: type=registry,ref=ghcr.io/aplinkosministerija/biip-hidro-api:buildcache
+      cache-to: type=registry,ref=ghcr.io/aplinkosministerija/biip-hidro-api:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,3 +16,5 @@ jobs:
       environment: Production
       enable-sentry: true
       docker-image: ghcr.io/AplinkosMinisterija/biip-hidro-api
+      cache-from: type=registry,ref=ghcr.io/aplinkosministerija/biip-hidro-api:buildcache
+      cache-to: type=registry,ref=ghcr.io/aplinkosministerija/biip-hidro-api:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -16,3 +16,5 @@ jobs:
       environment: Staging
       enable-sentry: true
       docker-image: ghcr.io/AplinkosMinisterija/biip-hidro-api
+      cache-from: type=registry,ref=ghcr.io/aplinkosministerija/biip-hidro-api:buildcache
+      cache-to: type=registry,ref=ghcr.io/aplinkosministerija/biip-hidro-api:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true


### PR DESCRIPTION
## What

Deploy workflows opt in to a ghcr.io registry buildx cache (`ghcr.io/aplinkosministerija/biip-hidro-api:buildcache`) instead of the default GitHub Actions cache backend. One shared cache tag across environments — the heavy dependency-install layers are identical between them.

## Why

Measured on biip-alis-* and biip-medziokle-api deploys: even on a full cache HIT, buildx re-downloads the cached dependency layer from the GHA cache API to the self-hosted runner at ~0.6–2 MB/s (biip-medziokle-api: a 312 MB layer took 497 s; biip-alis-web: 529 MB took 224 s — 80 % of build time). Pulling the same layers from ghcr.io (where the images already live) is much faster, and registry cache is not subject to the 10 GB GHA cache eviction. `ignore-error=true` keeps cache-export failures from ever failing a deploy.

## Notes

**Merge after AplinkosMinisterija/reusable-workflows#33** — it adds the `cache-from`/`cache-to` pass-through inputs; before that, these `with:` keys fail workflow validation. First deploy after merge is a cold cache (one-time full build); subsequent builds should shrink by minutes. Same change: biip-alis-api#64, biip-alis-web#69, biip-alis-admin-web#53, biip-medziokle-api#476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
